### PR TITLE
Removing any references to /scratch directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ docker run -v $PWD:/data2 nciccbr/ccbr_telescope:latest HERVx -r1 tests/small_S2
 # instance. This is useful for testing, debugging,
 # or when a users does not have access to a high
 # performance computing environment.
-./hervx local -r1 tests/small_S25.R1.fastq.gz -r2 tests/small_S25.R2.fastq.gz --outdir /scratch/$USER/hervx_output
+./hervx local -r1 tests/small_S25.R1.fastq.gz -r2 tests/small_S25.R2.fastq.gz --outdir /data/$USER/hervx_output
 
 # @slurm: uses slurm and singularity cromwell backend
 # The slurm EXECUTOR will submit jobs to the cluster.
 # It is recommended running hervx in this mode.
-./hervx slurm -r1 tests/small_S25.R1.fastq.gz -r2 tests/small_S25.R2.fastq.gz --outdir /scratch/$USER/hervx_output
+./hervx slurm -r1 tests/small_S25.R1.fastq.gz -r2 tests/small_S25.R2.fastq.gz --outdir /data/$USER/hervx_output
 ```
 
 ### 4. TLDR

--- a/config/local-singularity.conf
+++ b/config/local-singularity.conf
@@ -16,7 +16,7 @@ backend {
                   # Load Singularity into PATH
                   module load singularity
                   # Add cluster bind paths
-                  export SINGULARITY_BINDPATH="/vf,/gpfs,/spin1,/data,/scratch,/fdb,/lscratch"
+                  export SINGULARITY_BINDPATH="/vf,/gpfs,/spin1,/data,/fdb,/lscratch"
                   # should use local cache
                   singularity exec --containall --bind ${cwd}:${docker_cwd} docker://${docker} \
                       ${job_shell} ${docker_script}

--- a/config/slurm-singularity.conf
+++ b/config/slurm-singularity.conf
@@ -42,7 +42,7 @@ backend {
             # Load Singularity into PATH
             module load singularity
             # Add cluster bind paths
-            export SINGULARITY_BINDPATH="/vf,/gpfs,/spin1,/data,/scratch,/fdb,/lscratch"
+            export SINGULARITY_BINDPATH="/vf,/gpfs,/spin1,/data,/fdb,/lscratch"
 
             # SINGULARITY_CACHEDIR needs to point to a directory accessible by
             # the jobs (i.e. not lscratch). Might want to use a workflow local

--- a/hervx
+++ b/hervx
@@ -67,8 +67,8 @@ OPTIONS:
   -h, --help     [Type: Bool]  Displays usage and help information.
 
 Example:
-  $ hervx local -r1 $(dirname  "$0")/tests/small_S25.R1.fastq.gz -r2 $(dirname  "$0")/tests/small_S25.R2.fastq.gz --outdir /scratch/$USER/
-  $ hervx slurm -r1 $(dirname  "$0")/tests/small_S25.R1.fastq.gz -r2 $(dirname  "$0")/tests/small_S25.R2.fastq.gz --outdir /scratch/$USER/
+  $ hervx local -r1 $(dirname  "$0")/tests/small_S25.R1.fastq.gz -r2 $(dirname  "$0")/tests/small_S25.R2.fastq.gz --outdir /data/$USER/
+  $ hervx slurm -r1 $(dirname  "$0")/tests/small_S25.R1.fastq.gz -r2 $(dirname  "$0")/tests/small_S25.R2.fastq.gz --outdir /data/$USER/
 
 Version:
   0.0.1
@@ -83,7 +83,7 @@ function abspath() { readlink -e "$1"; }
 function parser() {
   # Adds parsed command-line args to GLOBAL $Arguments associative array
   # + KEYS = short_cli_flag ("r1", "r2", "o", ...)
-  # + VALUES = parsed_user_value ("WT_1.fastq" "WT_2.fastq", "/scratch", ...)
+  # + VALUES = parsed_user_value ("WT_1.fastq" "WT_2.fastq", "/data/$USER", ...)
   # @INPUT "$@" = user command-line arguments
   # @CALLS check() to see if the user provided all the required arguments
 

--- a/src/HERVx
+++ b/src/HERVx
@@ -74,7 +74,7 @@ function fatal() { cat <<< "$@" 1>&2; usage; exit 1; }
 function parser() {
   # Adds parsed command-line args to GLOBAL $Arguments associative array
   # + KEYS = short_cli_flag ("r1", "r2", "o", ...)
-  # + VALUES = parsed_user_value ("WT_1.fastq" "WT_2.fastq", "/scratch", ...)
+  # + VALUES = parsed_user_value ("WT_1.fastq" "WT_2.fastq", "/data/$USER", ...)
   # @INPUT "$@" = user command-line arguments
   # @CALLS check() to see if the user provided all the required arguments
 


### PR DESCRIPTION
`/scratch` directory can no longer be accessed via the compute nodes.